### PR TITLE
Add `--json` support to get and list

### DIFF
--- a/src/Commands/Get.swift
+++ b/src/Commands/Get.swift
@@ -9,8 +9,8 @@ struct Get: AsyncParsableCommand {
     @Argument(help: "Name of the virtual machine", completion: .custom(completeVMName))
     var name: String
     
-    @Flag(name: .long, help: "Outputs the images as a machine-readable JSON.")
-    var json = false
+    @Option(name: [.long, .customShort("f")], help: "Output format (json|text)")
+    var format: FormatOption = .text
     
     init() {
     }
@@ -19,6 +19,6 @@ struct Get: AsyncParsableCommand {
     func run() async throws {
         let vmController = LumeController()
         let vm = try vmController.get(name: name)
-        try VMDetailsPrinter.printStatus([vm.details], json: self.json)
+        try VMDetailsPrinter.printStatus([vm.details], format: self.format)
     }
 } 

--- a/src/Commands/Get.swift
+++ b/src/Commands/Get.swift
@@ -9,6 +9,9 @@ struct Get: AsyncParsableCommand {
     @Argument(help: "Name of the virtual machine", completion: .custom(completeVMName))
     var name: String
     
+    @Flag(name: .long, help: "Outputs the images as a machine-readable JSON.")
+    var json = false
+    
     init() {
     }
     
@@ -16,6 +19,6 @@ struct Get: AsyncParsableCommand {
     func run() async throws {
         let vmController = LumeController()
         let vm = try vmController.get(name: name)
-        VMDetailsPrinter.printStatus([vm.details])
+        try VMDetailsPrinter.printStatus([vm.details], json: self.json)
     }
 } 

--- a/src/Commands/List.swift
+++ b/src/Commands/List.swift
@@ -7,8 +7,8 @@ struct List: AsyncParsableCommand {
         abstract: "List virtual machines"
     )
     
-    @Flag(name: .long, help: "Outputs the images as a machine-readable JSON.")
-    var json = false
+    @Option(name: [.long, .customShort("f")], help: "Output format (json|text)")
+    var format: FormatOption = .text
     
     init() {
     }
@@ -17,10 +17,10 @@ struct List: AsyncParsableCommand {
     func run() async throws {
         let manager = LumeController()
         let vms = try manager.list()
-        if vms.isEmpty && !json {
+        if vms.isEmpty && self.format == .text {
             print("No virtual machines found")
         } else {
-            try VMDetailsPrinter.printStatus(vms, json: self.json)
+            try VMDetailsPrinter.printStatus(vms, format: self.format)
         }
     }
 }

--- a/src/Commands/List.swift
+++ b/src/Commands/List.swift
@@ -7,6 +7,9 @@ struct List: AsyncParsableCommand {
         abstract: "List virtual machines"
     )
     
+    @Flag(name: .long, help: "Outputs the images as a machine-readable JSON.")
+    var json = false
+    
     init() {
     }
     
@@ -14,10 +17,10 @@ struct List: AsyncParsableCommand {
     func run() async throws {
         let manager = LumeController()
         let vms = try manager.list()
-        if vms.isEmpty {
+        if vms.isEmpty && !json {
             print("No virtual machines found")
         } else {
-            VMDetailsPrinter.printStatus(vms)
+            try VMDetailsPrinter.printStatus(vms, json: self.json)
         }
     }
 }

--- a/src/Commands/Options/FormatOption.swift
+++ b/src/Commands/Options/FormatOption.swift
@@ -1,0 +1,6 @@
+import ArgumentParser
+
+enum FormatOption: String, ExpressibleByArgument {
+    case json
+    case text
+}

--- a/src/VM/VMDetailsPrinter.swift
+++ b/src/VM/VMDetailsPrinter.swift
@@ -33,8 +33,8 @@ enum VMDetailsPrinter {
     
     /// Prints the status of all VMs in a formatted table
     /// - Parameter vms: Array of VM status objects to display
-    static func printStatus(_ vms: [VMDetails], json: Bool, print: (String) -> () = { print($0) }) throws {
-        if json {
+    static func printStatus(_ vms: [VMDetails], format: FormatOption, print: (String) -> () = { print($0) }) throws {
+        if format == .json {
             let jsonEncoder = JSONEncoder()
             jsonEncoder.outputFormatting = .prettyPrinted
             let jsonData = try jsonEncoder.encode(vms)

--- a/src/VM/VMDetailsPrinter.swift
+++ b/src/VM/VMDetailsPrinter.swift
@@ -33,17 +33,25 @@ enum VMDetailsPrinter {
     
     /// Prints the status of all VMs in a formatted table
     /// - Parameter vms: Array of VM status objects to display
-    static func printStatus(_ vms: [VMDetails]) {
-        printHeader()
-        vms.forEach(printVM)
+    static func printStatus(_ vms: [VMDetails], json: Bool, print: (String) -> () = { print($0) }) throws {
+        if json {
+            let jsonEncoder = JSONEncoder()
+            jsonEncoder.outputFormatting = .prettyPrinted
+            let jsonData = try jsonEncoder.encode(vms)
+            let jsonString = String(data: jsonData, encoding: .utf8)!
+            print(jsonString)
+        } else {
+            printHeader(print: print)
+            vms.forEach({ printVM($0, print: print)})
+        }
     }
     
-    private static func printHeader() {
+    private static func printHeader(print: (String) -> () = { print($0) }) {
         let paddedHeaders = columns.map { $0.header.paddedToWidth($0.width) }
         print(paddedHeaders.joined())
     }
     
-    private static func printVM(_ vm: VMDetails) {
+    private static func printVM(_ vm: VMDetails, print: (String) -> Void = { print($0) }) {
         let paddedColumns = columns.map { column in
             column.getValue(vm).paddedToWidth(column.width)
         }

--- a/tests/VM/VMDetailsPrinterTests.swift
+++ b/tests/VM/VMDetailsPrinterTests.swift
@@ -20,7 +20,7 @@ struct VMDetailsPrinterTests {
         
         // When
         var printedStatus: String?
-        try VMDetailsPrinter.printStatus(vms, json: true, print: { printedStatus = $0 })
+        try VMDetailsPrinter.printStatus(vms, format: .json, print: { printedStatus = $0 })
 
         // Then
         #expect(printedStatus == expectedOutput)
@@ -39,7 +39,7 @@ struct VMDetailsPrinterTests {
         
         // When
         var printedLines: [String] = []
-        try VMDetailsPrinter.printStatus(vms, json: false, print: { printedLines.append($0) })
+        try VMDetailsPrinter.printStatus(vms, format: .text, print: { printedLines.append($0) })
 
         // Then
         #expect(printedLines.count == 2)
@@ -49,6 +49,6 @@ struct VMDetailsPrinterTests {
         #expect(headerParts == ["name", "os", "cpu", "memory", "disk", "status", "ip", "vnc"])
 
         let vmParts = printedLines[1].split(whereSeparator: \.isWhitespace)
-        #expect(vmParts == ["name", "os", "2", "0.00G", "24.0B/30.0B", "status", "0.0.0.0", "vncUrl"])        
+        #expect(vmParts == ["name", "os", "2", "0.00G", "24.0B/30.0B", "status", "0.0.0.0", "vncUrl"])
     }
 }

--- a/tests/VM/VMDetailsPrinterTests.swift
+++ b/tests/VM/VMDetailsPrinterTests.swift
@@ -5,50 +5,64 @@ import Foundation
 struct VMDetailsPrinterTests {
     
     @Test func printStatus_whenJSON() throws {
-        // Given
-        let vms: [VMDetails] = [VMDetails(name: "name",
-                                         os: "os",
-                                         cpuCount: 2,
-                                         memorySize: 1024,
-                                         diskSize: .init(allocated: 24, total: 30),
-                                         status: "status",
-                                         vncUrl: "vncUrl",
-                                         ipAddress: "0.0.0.0")]
-        let jsonEncoder = JSONEncoder()
-        jsonEncoder.outputFormatting = .prettyPrinted
-        let expectedOutput = try String(data: jsonEncoder.encode(vms), encoding: .utf8)!
-        
-        // When
-        var printedStatus: String?
-        try VMDetailsPrinter.printStatus(vms, format: .json, print: { printedStatus = $0 })
+            // Given
+            let vms: [VMDetails] = [VMDetails(name: "name",
+                                             os: "os",
+                                             cpuCount: 2,
+                                             memorySize: 1024,
+                                             diskSize: .init(allocated: 24, total: 30),
+                                             status: "status",
+                                             vncUrl: "vncUrl",
+                                             ipAddress: "0.0.0.0")]
+            let jsonEncoder = JSONEncoder()
+            jsonEncoder.outputFormatting = .prettyPrinted
+            let expectedOutput = try String(data: jsonEncoder.encode(vms), encoding: .utf8)!
+            
+            // When
+            var printedStatus: String?
+            try VMDetailsPrinter.printStatus(vms, format: .json, print: { printedStatus = $0 })
 
-        // Then
-        #expect(printedStatus == expectedOutput)
-    }
-    
-    @Test func printStatus_whenNotJSON() throws {
-        // Given
-        let vms: [VMDetails] = [VMDetails(name: "name",
-                                         os: "os",
-                                         cpuCount: 2,
-                                         memorySize: 1024,
-                                         diskSize: .init(allocated: 24, total: 30),
-                                         status: "status",
-                                         vncUrl: "vncUrl",
-                                         ipAddress: "0.0.0.0")]
+            // Then
+            // Decode both JSONs and compare the actual data structures
+            let jsonDecoder = JSONDecoder()
+            let printedVMs = try jsonDecoder.decode([VMDetails].self, from: printedStatus!.data(using: .utf8)!)
+            let expectedVMs = try jsonDecoder.decode([VMDetails].self, from: expectedOutput.data(using: .utf8)!)
+            
+            #expect(printedVMs.count == expectedVMs.count)
+            for (printed, expected) in zip(printedVMs, expectedVMs) {
+                #expect(printed.name == expected.name)
+                #expect(printed.os == expected.os)
+                #expect(printed.cpuCount == expected.cpuCount)
+                #expect(printed.memorySize == expected.memorySize)
+                #expect(printed.diskSize.allocated == expected.diskSize.allocated)
+                #expect(printed.diskSize.total == expected.diskSize.total)
+                #expect(printed.status == expected.status)
+                #expect(printed.vncUrl == expected.vncUrl)
+                #expect(printed.ipAddress == expected.ipAddress)
+            }
+        }
         
-        // When
-        var printedLines: [String] = []
-        try VMDetailsPrinter.printStatus(vms, format: .text, print: { printedLines.append($0) })
+        @Test func printStatus_whenNotJSON() throws {
+            // Given
+            let vms: [VMDetails] = [VMDetails(name: "name",
+                                             os: "os",
+                                             cpuCount: 2,
+                                             memorySize: 1024,
+                                             diskSize: .init(allocated: 24, total: 30),
+                                             status: "status",
+                                             vncUrl: "vncUrl",
+                                             ipAddress: "0.0.0.0")]
+            
+            // When
+            var printedLines: [String] = []
+            try VMDetailsPrinter.printStatus(vms, format: .text, print: { printedLines.append($0) })
 
-        // Then
-        #expect(printedLines.count == 2)
-        
-        
-        let headerParts = printedLines[0].split(whereSeparator: \.isWhitespace)
-        #expect(headerParts == ["name", "os", "cpu", "memory", "disk", "status", "ip", "vnc"])
+            // Then
+            #expect(printedLines.count == 2)
+            
+            let headerParts = printedLines[0].split(whereSeparator: \.isWhitespace)
+            #expect(headerParts == ["name", "os", "cpu", "memory", "disk", "status", "ip", "vnc"])
 
-        let vmParts = printedLines[1].split(whereSeparator: \.isWhitespace)
-        #expect(vmParts == ["name", "os", "2", "0.00G", "24.0B/30.0B", "status", "0.0.0.0", "vncUrl"])
-    }
+            #expect(printedLines[1].split(whereSeparator: \.isWhitespace).map(String.init) == ["name", "os", "2", "0.00G", "24.0B/30.0B", "status", "0.0.0.0", "vncUrl"])
+        }
 }

--- a/tests/VM/VMDetailsPrinterTests.swift
+++ b/tests/VM/VMDetailsPrinterTests.swift
@@ -1,0 +1,48 @@
+import Testing
+import Foundation
+@testable import lume
+
+struct VMDetailsPrinterTests {
+    
+    @Test func printStatus_whenJSON() throws {
+        // Given
+        let vms: [VMDetails] = [VMDetails(name: "name",
+                                         os: "os",
+                                         cpuCount: 2,
+                                         memorySize: 1024,
+                                         diskSize: .init(allocated: 24, total: 30),
+                                         status: "status",
+                                         vncUrl: "vncUrl",
+                                         ipAddress: "0.0.0.0")]
+        let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = .prettyPrinted
+        let expectedOutput = try String(data: jsonEncoder.encode(vms), encoding: .utf8)!
+        
+        // When
+        var printedStatus: String?
+        try VMDetailsPrinter.printStatus(vms, json: true, print: { printedStatus = $0 })
+
+        // Then
+        #expect(printedStatus == expectedOutput)
+    }
+    
+    @Test func printStatus_whenNotJSON() throws {
+        // Given
+        let vms: [VMDetails] = [VMDetails(name: "name",
+                                         os: "os",
+                                         cpuCount: 2,
+                                         memorySize: 1024,
+                                         diskSize: .init(allocated: 24, total: 30),
+                                         status: "status",
+                                         vncUrl: "vncUrl",
+                                         ipAddress: "0.0.0.0")]
+        
+        // When
+        var printedLines: [String] = []
+        try VMDetailsPrinter.printStatus(vms, json: false, print: { printedLines.append($0) })
+
+        // Then
+        #expect(printedLines.popLast() == "name                              os      2       0.00G   24.0B/30.0B     status          0.0.0.0         vncUrl                                            ")
+        #expect(printedLines.popLast() == "name                              os      cpu     memory  disk            status          ip              vnc                                               ")
+    }
+}

--- a/tests/VM/VMDetailsPrinterTests.swift
+++ b/tests/VM/VMDetailsPrinterTests.swift
@@ -42,7 +42,13 @@ struct VMDetailsPrinterTests {
         try VMDetailsPrinter.printStatus(vms, json: false, print: { printedLines.append($0) })
 
         // Then
-        #expect(printedLines.popLast() == "name                              os      2       0.00G   24.0B/30.0B     status          0.0.0.0         vncUrl                                            ")
-        #expect(printedLines.popLast() == "name                              os      cpu     memory  disk            status          ip              vnc                                               ")
+        #expect(printedLines.count == 2)
+        
+        
+        let headerParts = printedLines[0].split(whereSeparator: \.isWhitespace)
+        #expect(headerParts == ["name", "os", "cpu", "memory", "disk", "status", "ip", "vnc"])
+
+        let vmParts = printedLines[1].split(whereSeparator: \.isWhitespace)
+        #expect(vmParts == ["name", "os", "2", "0.00G", "24.0B/30.0B", "status", "0.0.0.0", "vncUrl"])        
     }
 }


### PR DESCRIPTION
I'm adding support for a `--json` flag to the `lume get` and `lume list` command. When interfacing with `lume` programmatically, having the responses as a decodable JSON is useful.
