### PR TITLE
Fix broken test: `VMDetailsPrinterTests`

### DIFF
--- a/tests/VM/VMDetailsPrinterTests.swift
+++ b/tests/VM/VMDetailsPrinterTests.swift
@@ -11,6 +11,7 @@ struct VMDetailsPrinterTests {
                                              cpuCount: 2,
                                              memorySize: 1024,
                                              diskSize: .init(allocated: 24, total: 30),
+                                             display: "1024x768",
                                              status: "status",
                                              vncUrl: "vncUrl",
                                              ipAddress: "0.0.0.0")]
@@ -49,6 +50,7 @@ struct VMDetailsPrinterTests {
                                              cpuCount: 2,
                                              memorySize: 1024,
                                              diskSize: .init(allocated: 24, total: 30),
+                                             display: "1024x768",
                                              status: "status",
                                              vncUrl: "vncUrl",
                                              ipAddress: "0.0.0.0")]
@@ -61,8 +63,8 @@ struct VMDetailsPrinterTests {
             #expect(printedLines.count == 2)
             
             let headerParts = printedLines[0].split(whereSeparator: \.isWhitespace)
-            #expect(headerParts == ["name", "os", "cpu", "memory", "disk", "status", "ip", "vnc"])
+            #expect(headerParts == ["name", "os", "cpu", "memory", "disk", "display", "status", "ip", "vnc"])
 
-            #expect(printedLines[1].split(whereSeparator: \.isWhitespace).map(String.init) == ["name", "os", "2", "0.00G", "24.0B/30.0B", "status", "0.0.0.0", "vncUrl"])
+            #expect(printedLines[1].split(whereSeparator: \.isWhitespace).map(String.init) == ["name", "os", "2", "0.00G", "24.0B/30.0B", "1024x768", "status", "0.0.0.0", "vncUrl"])
         }
 }


### PR DESCRIPTION
The test in `tests/VM/VMDetailsPrinterTests.swift` was broken.

```swift
Building for debugging...
[4/4] Write swift-version--58304C5D6DBC2206.txt
Build complete! (0.17s)
Building for debugging...
/Users/aktech/dev/lume/tests/VM/VMDetailsPrinterTests.swift:13:87: error: missing argument for parameter 'display' in call
11 |                                              cpuCount: 2,
12 |                                              memorySize: 1024,
13 |                                              diskSize: .init(allocated: 24, total: 30),
   |                                                                                       `- error: missing argument for parameter 'display' in call
14 |                                              status: "status",
15 |                                              vncUrl: "vncUrl",

/Users/aktech/dev/lume/src/VM/VMDetails.swift:43:5: note: 'init(name:os:cpuCount:memorySize:diskSize:display:status:vncUrl:ipAddress:)' declared here
41 |     let ipAddress: String?
42 |
43 |     init(
   |     `- note: 'init(name:os:cpuCount:memorySize:diskSize:display:status:vncUrl:ipAddress:)' declared here
44 |         name: String,
45 |         os: String,

/Users/aktech/dev/lume/tests/VM/VMDetailsPrinterTests.swift:51:87: error: missing argument for parameter 'display' in call
49 |                                              cpuCount: 2,
50 |                                              memorySize: 1024,
51 |                                              diskSize: .init(allocated: 24, total: 30),
   |                                                                                       `- error: missing argument for parameter 'display' in call
52 |                                              status: "status",
53 |                                              vncUrl: "vncUrl",

/Users/aktech/dev/lume/src/VM/VMDetails.swift:43:5: note: 'init(name:os:cpuCount:memorySize:diskSize:display:status:vncUrl:ipAddress:)' declared here
41 |     let ipAddress: String?
42 |
43 |     init(
   |     `- note: 'init(name:os:cpuCount:memorySize:diskSize:display:status:vncUrl:ipAddress:)' declared here
44 |         name: String,
45 |         os: String,
[7/8] Compiling lumeTests VMDetailsPrinterTests.swift
error: fatalError
```

This was due to missing `display` argument. This PR fixes the same.